### PR TITLE
[fix] mise: revert `--omit-history`

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,5 +3,5 @@
 "aqua:mvdan/sh" = "latest"
 
 [env]
-X_PODMAN_COMMON = "--format=oci --layers=false --squash-all --identity-label=false --omit-history"
+X_PODMAN_COMMON = "--format=oci --layers=false --squash-all --identity-label=false"
 X_PODMAN_MANIFEST_REGISTRY = "localhost"


### PR DESCRIPTION
Setting propagates downstream (?).

Images dependent on `base` will not include any history disabling layer caching capabilities, so we revert this flag.